### PR TITLE
Added better mutability, removed some clones

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,10 +107,10 @@ impl Node {
     /// ```
     /// use html_editor::{Node, Element};
     ///
-    /// let a: Node = Node::new_element("div", vec![("id", "app")], vec![]);
+    /// let mut a: Node = Node::new_element("div", vec![("id", "app")], vec![]);
     /// assert!(a.as_element_mut().is_some());
     ///
-    /// let b: Node = Node::Text("hello".to_string());
+    /// let mut b: Node = Node::Text("hello".to_string());
     /// assert!(b.as_element_mut().is_none());
     /// ```
     pub fn as_element_mut(&mut self) -> Option<&mut Element> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,10 +108,10 @@ impl Node {
     /// use html_editor::{Node, Element};
     ///
     /// let a: Node = Node::new_element("div", vec![("id", "app")], vec![]);
-    /// assert!(a.as_element().is_some());
+    /// assert!(a.as_element_mut().is_some());
     ///
     /// let b: Node = Node::Text("hello".to_string());
-    /// assert!(b.as_element().is_none());
+    /// assert!(b.as_element_mut().is_none());
     /// ```
     pub fn as_element_mut(&mut self) -> Option<&mut Element> {
         match self {

--- a/src/operation/edit.rs
+++ b/src/operation/edit.rs
@@ -52,7 +52,7 @@ pub trait Editable {
     /// <div>
     ///     <div class="recommend"></div>
     ///     <div class="results"></div>
-    ///     <span>foo</span>    <div class="ad"></div>    <span>bar</span>
+    ///     <div class="ad"></div>
     /// </div>"#;
     ///
     /// let selector = Selector::from(".ad");
@@ -61,7 +61,7 @@ pub trait Editable {
     /// <div>
     ///     <div class="recommend"></div>
     ///     <div class="results"></div>
-    ///     <span>foo</span>        <span>bar</span>
+    ///    
     /// </div>"#)
     /// ```
     fn remove_by(&mut self, selector: &Selector) -> &mut Self;

--- a/src/operation/edit.rs
+++ b/src/operation/edit.rs
@@ -42,7 +42,6 @@ pub trait Editable {
     /// ```
     fn insert_to(&mut self, selector: &Selector, target: Node) -> &mut Self;
 
-    #[rustfmt::skip]
     /// Remove all elements that matches the `selector`.
     ///
     /// ```
@@ -53,7 +52,7 @@ pub trait Editable {
     /// <div>
     ///     <div class="recommend"></div>
     ///     <div class="results"></div>
-    ///     <div class="ad"></div><p></p>
+    ///     <span>foo</span>    <div class="ad"></div>    <span>bar</span>
     /// </div>"#;
     ///
     /// let selector = Selector::from(".ad");
@@ -62,7 +61,7 @@ pub trait Editable {
     /// <div>
     ///     <div class="recommend"></div>
     ///     <div class="results"></div>
-    ///     <p></p>
+    ///     <span>foo</span>        <span>bar</span>
     /// </div>"#)
     /// ```
     fn remove_by(&mut self, selector: &Selector) -> &mut Self;

--- a/src/operation/edit.rs
+++ b/src/operation/edit.rs
@@ -42,6 +42,7 @@ pub trait Editable {
     /// ```
     fn insert_to(&mut self, selector: &Selector, target: Node) -> &mut Self;
 
+    #[rustfmt::skip]
     /// Remove all elements that matches the `selector`.
     ///
     /// ```
@@ -52,7 +53,7 @@ pub trait Editable {
     /// <div>
     ///     <div class="recommend"></div>
     ///     <div class="results"></div>
-    ///     <div class="ad"></div>
+    ///     <div class="ad"></div><p></p>
     /// </div>"#;
     ///
     /// let selector = Selector::from(".ad");
@@ -61,7 +62,7 @@ pub trait Editable {
     /// <div>
     ///     <div class="recommend"></div>
     ///     <div class="results"></div>
-    ///    
+    ///     <p></p>
     /// </div>"#)
     /// ```
     fn remove_by(&mut self, selector: &Selector) -> &mut Self;
@@ -76,8 +77,8 @@ impl Editable for Vec<Node> {
             Node::Element { .. } => true,
         });
         for node in self.iter_mut() {
-            if let Node::Element { children, .. } = node {
-                children.trim();
+            if let Node::Element(el) = node {
+                el.children.trim();
             }
         }
         self
@@ -85,19 +86,14 @@ impl Editable for Vec<Node> {
 
     fn insert_to(&mut self, selector: &Selector, target: Node) -> &mut Self {
         for node in self.iter_mut() {
-            if let Node::Element {
-                name,
-                attrs,
-                children,
-            } = node
-            {
-                children.insert_to(selector, target.clone());
+            if let Node::Element(el) = node {
+                el.children.insert_to(selector, target.clone());
                 if selector.matches(&Element {
-                    name: name.clone(),
-                    attrs: attrs.clone(),
+                    name: el.name.clone(),
+                    attrs: el.attrs.clone(),
                     children: vec![],
                 }) {
-                    children.push(target.clone());
+                    el.children.push(target.clone());
                 }
             }
         }
@@ -106,10 +102,10 @@ impl Editable for Vec<Node> {
 
     fn remove_by(&mut self, selector: &Selector) -> &mut Self {
         self.retain(|node| {
-            if let Node::Element { name, attrs, .. } = node {
+            if let Node::Element(el) = node {
                 let element = Element {
-                    name: name.clone(),
-                    attrs: attrs.clone(),
+                    name: el.name.clone(),
+                    attrs: el.attrs.clone(),
                     children: vec![],
                 };
                 return !selector.matches(&element);
@@ -117,8 +113,8 @@ impl Editable for Vec<Node> {
             true
         });
         for node in self.iter_mut() {
-            if let Node::Element { children, .. } = node {
-                children.remove_by(selector);
+            if let Node::Element(el) = node {
+                el.remove_by(selector);
             }
         }
         self

--- a/src/operation/html.rs
+++ b/src/operation/html.rs
@@ -66,7 +66,7 @@ impl Htmlifiable for Element {
 impl Htmlifiable for Node {
     fn html(&self) -> String {
         match self {
-            Node::Element { .. } => self.clone().into_element().html(),
+            Node::Element(element) => element.html(),
             Node::Text(text) => text.to_string(),
             Node::Comment(comment) => format!("<!--{}-->", comment),
             Node::Doctype(doctype) => match &doctype {

--- a/src/operation/query.rs
+++ b/src/operation/query.rs
@@ -22,9 +22,9 @@ pub trait Queryable {
     ///     </html>"#;
     ///
     /// let selector: Selector = Selector::from("#app");
-    /// let app: Element = parse(html).unwrap().query(&selector).unwrap();
+    /// let app: &Element = parse(html).unwrap().query(&selector).unwrap();
     /// ```
-    fn query(&self, selector: &Selector) -> Option<Element>;
+    fn query(&self, selector: &Selector) -> Option<&Element>;
 
     /// Query all the nodes in `self` for the given selector.
     ///
@@ -47,20 +47,99 @@ pub trait Queryable {
     ///     </html>"#;
     ///
     /// let selector: Selector = Selector::from(".btn");
-    /// let app: Vec<Element> = parse(html).unwrap().query_all(&selector);
+    /// let buttons: Vec<&Element> = parse(html).unwrap().query_all(&selector);
     /// ```
-    fn query_all(&self, selector: &Selector) -> Vec<Element>;
+    fn query_all(&self, selector: &Selector) -> Vec<&Element>;
+
+    /// Query the node in `self` as mutable for the given selector.
+    ///
+    /// ```
+    /// use html_editor::{parse, Element};
+    /// use html_editor::operation::*;
+    ///
+    /// let html = r#"
+    ///     <!DOCTYPE html>
+    ///     <html lang="en">
+    ///     <head>
+    ///         <meta charset="UTF-8">
+    ///         <title>App</title>
+    ///     </head>
+    ///     <body>
+    ///         <div id="app"></div>
+    ///     </body>
+    ///     </html>"#;
+    ///
+    /// let selector: Selector = Selector::from("#app");
+    /// let app: &mut Element = parse(html).unwrap().query_mut(&selector).unwrap();
+    /// ```
+    fn query_mut(&mut self, selector: &Selector) -> Option<&mut Element>;
+
+    /// Executes a given function for the node in `self` for the given selector.
+    ///
+    /// ```
+    /// use html_editor::{parse, Element, Node};
+    /// use html_editor::operation::*;
+    ///
+    /// let html = r#"
+    ///    <!DOCTYPE html>
+    ///    <html lang="en">
+    ///        <head>
+    ///           <meta charset="UTF-8">
+    ///           <title>App</title>
+    ///        </head>
+    ///        <body>
+    ///           <input type="text" />
+    ///           <input type="text" />
+    ///           <input type="text" />
+    ///        </body>
+    ///    </html>"#;
+    ///
+    /// // Add a class to all the input elements
+    /// let selector: Selector = Selector::from("input");
+    /// let mut doc: Vec<Node> = parse(html).unwrap();
+    /// doc.execute_for(&selector, |elem| {
+    ///    elem.attrs.push(("class".to_string(), "input".to_string()));
+    /// });
+    /// ```
+    fn execute_for(&mut self, selector: &Selector, f: impl FnMut(&mut Element));
+}
+
+// We meed this function to allow the trait interface to use `impl FnMut(&mut Element)` instead of `&mut impl FnMut(&mut Element)`
+fn nodes_execute_for_internal(
+    nodes: &mut Vec<Node>,
+    selector: &Selector,
+    f: &mut impl FnMut(&mut Element),
+) {
+    for node in nodes {
+        if let Some(element) = node.as_element_mut() {
+            // Check if this element matches. If so, execute the function on it
+            if selector.matches(&element) {
+                f(element);
+            }
+
+            // Recursively traverse the descendants nodes
+            element_execute_for_internal(element, selector, f);
+        }
+    }
+}
+
+// We meed this function to allow the trait interface to use `impl FnMut(&mut Element)` instead of `&mut impl FnMut(&mut Element)`
+fn element_execute_for_internal(
+    element: &mut Element,
+    selector: &Selector,
+    f: &mut impl FnMut(&mut Element),
+) {
+    if selector.matches(&element) {
+        f(element);
+    }
+    nodes_execute_for_internal(&mut element.children, selector, f);
 }
 
 impl Queryable for Vec<Node> {
-    fn query(&self, selector: &Selector) -> Option<Element> {
+    fn query(&self, selector: &Selector) -> Option<&Element> {
         for node in self {
-            if node.is_element() {
-                let element = node.clone().into_element();
-
-                if selector.matches(&element) {
-                    return Some(element);
-                } else if let Some(elem) = element.query(selector) {
+            if let Some(element) = node.as_element() {
+                if let Some(elem) = element.query(selector) {
                     return Some(elem);
                 }
             }
@@ -68,30 +147,92 @@ impl Queryable for Vec<Node> {
         None
     }
 
-    fn query_all(&self, selector: &Selector) -> Vec<Element> {
+    fn query_all(&self, selector: &Selector) -> Vec<&Element> {
         let mut elements = Vec::new();
         for node in self {
-            if node.is_element() {
-                let element = node.clone().into_element();
+            if let Some(element) = node.as_element() {
                 // Recursively traverse the descendants nodes
                 let sub_elements = element.query_all(selector);
                 elements.extend(sub_elements);
-                // Check if this element matches. If so, push it to the `elements`
-                if selector.matches(&element) {
-                    elements.push(element);
-                }
             }
         }
         elements
     }
+
+    fn query_mut(&mut self, selector: &Selector) -> Option<&mut Element> {
+        for node in self {
+            if let Some(element) = node.as_element_mut() {
+                if let Some(elem) = element.query_mut(selector) {
+                    return Some(elem);
+                }
+            }
+        }
+        None
+    }
+
+    fn execute_for(&mut self, selector: &Selector, mut f: impl FnMut(&mut Element)) {
+        nodes_execute_for_internal(self, selector, &mut f);
+    }
 }
 
 impl Queryable for Element {
-    fn query(&self, selector: &Selector) -> Option<Element> {
-        self.children.query(selector)
+    fn query(&self, selector: &Selector) -> Option<&Element> {
+        if selector.matches(&self) {
+            Some(self)
+        } else {
+            self.children.query(selector)
+        }
     }
 
-    fn query_all(&self, selector: &Selector) -> Vec<Element> {
-        self.children.query_all(selector)
+    fn query_all(&self, selector: &Selector) -> Vec<&Element> {
+        let mut elements = self.children.query_all(selector);
+        if selector.matches(&self) {
+            elements.push(self);
+        }
+        elements
+    }
+
+    fn query_mut(&mut self, selector: &Selector) -> Option<&mut Element> {
+        if selector.matches(&self) {
+            Some(self)
+        } else {
+            self.children.query_mut(selector)
+        }
+    }
+
+    fn execute_for(&mut self, selector: &Selector, mut f: impl FnMut(&mut Element)) {
+        element_execute_for_internal(self, selector, &mut f);
+    }
+}
+
+impl Queryable for Node {
+    fn query(&self, selector: &Selector) -> Option<&Element> {
+        if let Some(element) = self.as_element() {
+            element.query(selector)
+        } else {
+            None
+        }
+    }
+
+    fn query_all(&self, selector: &Selector) -> Vec<&Element> {
+        if let Some(element) = self.as_element() {
+            element.query_all(selector)
+        } else {
+            Vec::new()
+        }
+    }
+
+    fn query_mut(&mut self, selector: &Selector) -> Option<&mut Element> {
+        if let Some(element) = self.as_element_mut() {
+            element.query_mut(selector)
+        } else {
+            None
+        }
+    }
+
+    fn execute_for(&mut self, selector: &Selector, f: impl FnMut(&mut Element)) {
+        if let Some(element) = self.as_element_mut() {
+            element.execute_for(selector, f);
+        }
     }
 }

--- a/src/operation/query.rs
+++ b/src/operation/query.rs
@@ -112,11 +112,6 @@ fn nodes_execute_for_internal(
 ) {
     for node in nodes {
         if let Some(element) = node.as_element_mut() {
-            // Check if this element matches. If so, execute the function on it
-            if selector.matches(&element) {
-                f(element);
-            }
-
             // Recursively traverse the descendants nodes
             element_execute_for_internal(element, selector, f);
         }

--- a/src/operation/query.rs
+++ b/src/operation/query.rs
@@ -124,7 +124,7 @@ fn element_execute_for_internal(
     selector: &Selector,
     f: &mut impl FnMut(&mut Element),
 ) {
-    if selector.matches(&element) {
+    if selector.matches(element) {
         f(element);
     }
     nodes_execute_for_internal(&mut element.children, selector, f);
@@ -172,7 +172,7 @@ impl Queryable for Vec<Node> {
 
 impl Queryable for Element {
     fn query(&self, selector: &Selector) -> Option<&Element> {
-        if selector.matches(&self) {
+        if selector.matches(self) {
             Some(self)
         } else {
             self.children.query(selector)
@@ -181,14 +181,14 @@ impl Queryable for Element {
 
     fn query_all(&self, selector: &Selector) -> Vec<&Element> {
         let mut elements = self.children.query_all(selector);
-        if selector.matches(&self) {
+        if selector.matches(self) {
             elements.push(self);
         }
         elements
     }
 
     fn query_mut(&mut self, selector: &Selector) -> Option<&mut Element> {
-        if selector.matches(&self) {
+        if selector.matches(self) {
             Some(self)
         } else {
             self.children.query_mut(selector)

--- a/src/parse/token.rs
+++ b/src/parse/token.rs
@@ -1,5 +1,5 @@
 use crate::parse::attrs;
-use crate::{Doctype, Node};
+use crate::{Doctype, Element, Node};
 
 #[derive(Debug, Clone)]
 pub enum Token {
@@ -89,24 +89,51 @@ impl Token {
 
     pub fn into_node(self) -> Node {
         match self {
-            Self::Start(name, attrs) => Node::Element {
+            Self::Start(name, attrs) => Element {
+                name,
+                attrs,
+                children: Vec::new(),
+            }
+            .into_node(),
+
+            Self::End(name) => Element {
+                name,
+                attrs: Vec::new(),
+                children: Vec::new(),
+            }
+            .into_node(),
+
+            Self::Closing(name, attrs) => Element {
+                name,
+                attrs,
+                children: Vec::new(),
+            }
+            .into_node(),
+
+            Self::Doctype(doctype) => Node::Doctype(doctype),
+            Self::Comment(comment) => Node::Comment(comment),
+            Self::Text(text) => Node::Text(text),
+        }
+    }
+
+    pub fn into_element(self) -> Element {
+        match self {
+            Self::Start(name, attrs) => Element {
                 name,
                 attrs,
                 children: Vec::new(),
             },
-            Self::End(name) => Node::Element {
+            Self::End(name) => Element {
                 name,
                 attrs: Vec::new(),
                 children: Vec::new(),
             },
-            Self::Closing(name, attrs) => Node::Element {
+            Self::Closing(name, attrs) => Element {
                 name,
                 attrs,
                 children: Vec::new(),
             },
-            Self::Doctype(doctype) => Node::Doctype(doctype),
-            Self::Comment(comment) => Node::Comment(comment),
-            Self::Text(text) => Node::Text(text),
+            _ => panic!("Cannot convert token to element"),
         }
     }
 }

--- a/tests/query.rs
+++ b/tests/query.rs
@@ -24,14 +24,21 @@ fn nodes_query_all() {
 fn element_query() {
     let nodes = parse(HTML).unwrap();
     let node = nodes.into_iter().nth(1).unwrap();
-    let _element = node.into_element().query(&Selector::from("span")).unwrap();
+    let _element = node
+        .as_element()
+        .unwrap()
+        .query(&Selector::from("span"))
+        .unwrap();
 }
 
 #[test]
 fn element_query_all() {
     let nodes = parse(HTML).unwrap();
     let node = nodes.into_iter().nth(1).unwrap();
-    let _elements = node.into_element().query_all(&Selector::from("span"));
+    let _elements = node
+        .as_element()
+        .unwrap()
+        .query_all(&Selector::from("span"));
 }
 
 #[test]


### PR DESCRIPTION
I started using this library in order to modify attributes in my HTML archiver (e.g. modify image src attributes, etc). However I noticed that this library doesn't support mutably querying elements by selectors, so instead of manually implementing it in my code I decided to fork this library instead. Along the way, I modified some other things as well.

Here is the full list of whats changed, off the top of my head:
- Node::Element now has (Element) instead of { element's fields }. This means we don't need to borrow (or clone) things across when coverting a Node into an Element.
- The above means that the number of clones went down significantly, previously it would make heaps of unnecessary clones when querying (cloning an entire tree just to get the next child element, etc).
- Made query functions return references instead of owned+cloned values. This is both better for performance, but also it lets the queries return &mut references, which is useful for editing the html
- Added a function that mutably executes a closure on all elements that match a selector, this is very useful for editing element attributes.
- Removed `.into_element`, instead it's `.as_element` which returns an option of the borrowed element inside.
- Implemented `.into_node` for Element for easier conversion, as well as an `Into<Node>` just in case.

Also, for the doctest in the remove_by function, I added an extra element in that line so that the IDE's auto formatter (not even rustfmt) doesn't strip the extra spaces from that line. VS Code automatically trims the end of each line, which makes that test fail after saving the file.