### PR TITLE
Encode and decode HTML escape codes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,23 @@
 version = 3
 
 [[package]]
+name = "html-escape"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d1ad449764d627e22bfd7cd5e8868264fc9236e07c752972b4080cd351cb476"
+dependencies = [
+ "utf8-width",
+]
+
+[[package]]
 name = "html_editor"
 version = "0.5.2"
+dependencies = [
+ "html-escape",
+]
+
+[[package]]
+name = "utf8-width"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5190c9442dcdaf0ddd50f37420417d219ae5261bbf5db120d0f9bab996c9cba1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ license = "MIT"
 keywords = ["html", "parser", "editor", "dom"]
 
 [dependencies]
+html-escape = "0.2.13"

--- a/src/operation/html.rs
+++ b/src/operation/html.rs
@@ -43,7 +43,7 @@ impl Htmlifiable for Element {
                 if v.is_empty() {
                     k.to_string()
                 } else {
-                    format!(r#"{}="{}""#, k, v)
+                    format!(r#"{}="{}""#, k, html_escape::encode_double_quoted_attribute(&v).into_owned())
                 }
             })
             .collect::<Vec<_>>()
@@ -67,7 +67,7 @@ impl Htmlifiable for Node {
     fn html(&self) -> String {
         match self {
             Node::Element(element) => element.html(),
-            Node::Text(text) => text.to_string(),
+            Node::Text(text) => html_escape::encode_text(text).into_owned(),
             Node::Comment(comment) => format!("<!--{}-->", comment),
             Node::Doctype(doctype) => match &doctype {
                 Doctype::Html => "<!DOCTYPE html>".to_string(),

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -75,7 +75,7 @@ fn html_to_stack(html: &str) -> Result<Vec<Token>, String> {
                         let txt_text = String::from_iter(chars_stack);
                         chars_stack = Vec::new();
                         // Push the text we just got to the token stack.
-                        token_stack.push(Token::Text(txt_text));
+                        token_stack.push(Token::from_text(txt_text));
                     }
                     chars_stack.push(ch);
                 }
@@ -120,7 +120,7 @@ fn html_to_stack(html: &str) -> Result<Vec<Token>, String> {
     }
     if !chars_stack.is_empty() {
         let text = String::from_iter(chars_stack);
-        token_stack.push(Token::Text(text));
+        token_stack.push(Token::from_text(text));
     }
     Ok(token_stack)
 }

--- a/src/parse/attrs.rs
+++ b/src/parse/attrs.rs
@@ -70,7 +70,7 @@ pub fn parse(attr_str: String) -> Vec<(String, String)> {
                             attr_pos = AttrPos::Space;
                             let value = String::from_iter(chars_stack);
                             chars_stack = Vec::new();
-                            value_stack.push(value)
+                            value_stack.push(html_escape::decode_html_entities(&value).into_owned())
                         }
                     } else {
                         chars_stack.push(ch)

--- a/src/parse/token.rs
+++ b/src/parse/token.rs
@@ -83,6 +83,10 @@ impl Token {
         Self::Comment(comment[4..comment.len() - 3].to_string())
     }
 
+    pub fn from_text(text: String) -> Self {
+        Self::Text(html_escape::decode_html_entities(&text).into_owned())
+    }
+
     pub fn node(&self) -> Node {
         self.clone().into_node()
     }

--- a/tests/escapes.rs
+++ b/tests/escapes.rs
@@ -1,20 +1,20 @@
 use html_editor::operation::*;
 use html_editor::{parse, Node, Element};
 
-const HTML: &str = r#"
-    <!DOCTYPE html>
-    <html lang="en">
-    <head>
-        <meta charset="UTF-8">
-        <title>I &lt;3 &#34;escaping&#34;</title>
-    </head>
-    <body>
-        <div id="testee" attr="id-with-&quot;quotes&quot;-inside"></div>
-    </body>
-    </html>"#;
-
 #[test]
 fn test_parse() {
+    const HTML: &str = r#"
+        <!DOCTYPE html>
+        <html lang="en">
+        <head>
+            <meta charset="UTF-8">
+            <title>I &lt;3 &#34;escaping&#34;</title>
+        </head>
+        <body>
+            <div id="testee" attr="id-with-&quot;quotes&quot;-inside"></div>
+        </body>
+        </html>"#;
+
     let html = parse(HTML).unwrap();
     let title_selector = Selector::from("title");
 
@@ -57,3 +57,70 @@ fn test_generate() {
     assert_eq!(generated, r#"<dummy-tag attr-1="attribute containing &lt; and &quot; and &amp;">fake &lt;tag&gt;</dummy-tag>"#);
 }
 
+// Nothing inside script and style tags should be escaped
+#[test]
+fn no_unescapes_in_script_and_style() {
+    const HTML: &str = r#"
+        <!DOCTYPE html>
+        <html lang="en">
+        <head>
+            <script>let text = "this tag shouldn't be escaped -> <p> hi </p>"</script>
+            <style>main:before { content: "fake <b>tag</b>"; }</style>
+        </head>
+        </html>"#;
+
+    let html = parse(HTML).unwrap();
+
+    let script_selector = Selector::from("script");
+
+    let Some(script) = html.query(&script_selector) else {
+        assert!(false, "Couldn't find script");
+        return;
+    };
+
+    assert_eq!(script.name, "script");
+    let Some(Node::Text(script_content)) = script.children.get(0) else {
+        assert!(false, "Invalid script contents");
+        return;
+    };
+
+    assert_eq!(script_content, r#"let text = "this tag shouldn't be escaped -> <p> hi </p>""#);
+
+    let style_selector = Selector::from("style");
+
+    let Some(style) = html.query(&style_selector) else {
+        assert!(false, "Couldn't find style");
+        return;
+    };
+
+    assert_eq!(style.name, "style");
+    let Some(Node::Text(style_content)) = style.children.get(0) else {
+        assert!(false, "Invalid script contents");
+        return;
+    };
+
+    assert_eq!(style_content, r#"main:before { content: "fake <b>tag</b>"; }"#);
+}
+
+#[test]
+fn no_escapes_in_script_and_style() {
+    let element = Element::new(
+        "head",
+        vec![],
+        vec![
+            Node::Element(Element::new(
+                "script",
+                vec![],
+                vec![Node::Text(r#"let text = "this tag shouldn't be escaped -> <p> hi </p>""#.into())],
+            )),
+            Node::Element(Element::new(
+                "style",
+                vec![],
+                vec![Node::Text(r#"main:before { content: "fake <b>tag</b>"; }"#.into())],
+            )),
+        ],
+    );
+
+    let generated = element.html();
+    assert_eq!(generated, r#"<head><script>let text = "this tag shouldn't be escaped -> <p> hi </p>"</script><style>main:before { content: "fake <b>tag</b>"; }</style></head>"#);
+}

--- a/tests/escapes.rs
+++ b/tests/escapes.rs
@@ -1,0 +1,59 @@
+use html_editor::operation::*;
+use html_editor::{parse, Node, Element};
+
+const HTML: &str = r#"
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <title>I &lt;3 &#34;escaping&#34;</title>
+    </head>
+    <body>
+        <div id="testee" attr="id-with-&quot;quotes&quot;-inside"></div>
+    </body>
+    </html>"#;
+
+#[test]
+fn test_parse() {
+    let html = parse(HTML).unwrap();
+    let title_selector = Selector::from("title");
+
+    let Some(title) = html.query(&title_selector) else {
+        assert!(false, "Invalid title");
+        return;
+    };
+
+    assert_eq!(title.name, "title");
+    let Some(Node::Text(title_content)) = title.children.get(0) else {
+        assert!(false, "Invalid title contents");
+        return;
+    };
+    assert_eq!(title_content, "I <3 \"escaping\"");
+
+    let div_selector = Selector::from("#testee");
+
+    let Some(div) = html.query(&div_selector) else {
+        assert!(false, "Invalid div");
+        return;
+    };
+
+    assert_eq!(
+        div.attrs,
+        vec![
+            ("attr".into(), "id-with-\"quotes\"-inside".into()),
+            ("id".into(), "testee".into()),
+        ]);
+}
+
+#[test]
+fn test_generate() {
+    let element = Element::new(
+        "dummy-tag",
+        vec![("attr-1".into(), "attribute containing < and \" and &".into())],
+        vec![Node::Text("fake <tag>".into())],
+    );
+
+    let generated = element.html();
+    assert_eq!(generated, r#"<dummy-tag attr-1="attribute containing &lt; and &quot; and &amp;">fake &lt;tag&gt;</dummy-tag>"#);
+}
+


### PR DESCRIPTION
Attempts to solve https://github.com/lomirus/html_editor/issues/9

Escaping is always hard to get 100% in all edge cases. This PR should handle escapes properly inside `Text`s and attribute values. I'm not sure whether attribute keys can be escaped, so they aren't handled. `<script>` and `<style>` are respected in that entities inside them aren't decoded in parsing nor encoded in Htmlification. Some tests have been added.

As this is a breaking change, the version should probably be bumped to 0.6 before merging.