### PR TITLE
Improve error handling in parsing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ mod parse;
 
 pub mod operation;
 
-pub use parse::parse;
+pub use parse::{parse, SourceLocation, HTMLParseError, InnerHTMLParseError};
 pub use parse::try_parse;
 
 /// Doctype of Html or Xml

--- a/src/parse/token.rs
+++ b/src/parse/token.rs
@@ -20,7 +20,7 @@ pub enum Token {
 impl Token {
     pub fn from(tag: String) -> Result<Self, InnerHTMLParseError> {
         if tag.ends_with("/>") {
-            let tag_name_start = tag[1..tag.len()]
+            let tag_name_start = tag[1..tag.len()-2]
                 .chars()
                 .position(|x| x != ' ')
                 .map(|x| x + 1)
@@ -58,7 +58,7 @@ impl Token {
 
             Ok(Self::Doctype(Doctype::Xml { version, encoding }))
         } else if tag.starts_with('<') {
-            let tag_name_start = tag[1..tag.len()]
+            let tag_name_start = tag[1..tag.len()-1]
                 .chars()
                 .position(|x| !x.is_ascii_whitespace())
                 .map(|x| x + 1)

--- a/src/parse/token.rs
+++ b/src/parse/token.rs
@@ -1,4 +1,4 @@
-use crate::parse::attrs;
+use crate::parse::{attrs, InnerHTMLParseError};
 use crate::{Doctype, Element, Node};
 
 #[derive(Debug, Clone)]
@@ -18,13 +18,13 @@ pub enum Token {
 }
 
 impl Token {
-    pub fn from(tag: String) -> Result<Self, String> {
+    pub fn from(tag: String) -> Result<Self, InnerHTMLParseError> {
         if tag.ends_with("/>") {
             let tag_name_start = tag[1..tag.len()]
                 .chars()
                 .position(|x| x != ' ')
-                .expect("tag name cannot be all spaces after \"<\"")
-                + 1;
+                .map(|x| x + 1)
+                .ok_or_else(|| InnerHTMLParseError::InvalidTag { tag: tag.clone(), reason: "Tag name cannot be all spaces after \"<\"" })?;
             let tag_name_end_option = tag[tag_name_start..tag.len()]
                 .chars()
                 .position(|x| x == ' ');
@@ -47,25 +47,27 @@ impl Token {
             let version = attr
                 .iter()
                 .find(|(name, _)| name == "version")
-                .expect("cannot find version attribute in xml declaration")
-                .1
-                .to_string();
+                .map(|x| x.1.to_string())
+                .ok_or_else(|| InnerHTMLParseError::InvalidTag { tag: tag.clone(), reason: "Cannot find version attribute in xml declaration" })?;
+
             let encoding = attr
                 .iter()
                 .find(|(name, _)| name == "encoding")
-                .expect("cannot find encoding attribute in xml declaration")
-                .1
-                .to_string();
+                .map(|x| x.1.to_string())
+                .ok_or_else(|| InnerHTMLParseError::InvalidTag { tag: tag.clone(), reason: "Cannot find encoding attribute in xml declaration" })?;
+
             Ok(Self::Doctype(Doctype::Xml { version, encoding }))
         } else if tag.starts_with('<') {
             let tag_name_start = tag[1..tag.len()]
                 .chars()
                 .position(|x| !x.is_ascii_whitespace())
-                .expect("tag name cannot be all spaces after \"<\"")
-                + 1;
+                .map(|x| x + 1)
+                .ok_or_else(|| InnerHTMLParseError::InvalidTag { tag: tag.clone(), reason: "Tag name cannot be all spaces after \"<\"" })?;
+
             let tag_name_end_option = tag[tag_name_start..tag.len()]
                 .chars()
                 .position(|x| x.is_ascii_whitespace());
+
             let tag_name_end = match tag_name_end_option {
                 Some(end) => end + tag_name_start,
                 None => tag.len() - 1,
@@ -74,7 +76,7 @@ impl Token {
             let attr_str = tag[tag_name_end..tag.len() - 1].trim().to_string();
             Ok(Self::Start(tag_name, attrs::parse(attr_str)))
         } else {
-            Err(format!("Invalid tag: {}", tag))
+            Err(InnerHTMLParseError::InvalidTag { tag, reason: "Invalid tag" })
         }
     }
 

--- a/tests/parse_error.rs
+++ b/tests/parse_error.rs
@@ -1,0 +1,114 @@
+use html_editor::{parse, InnerHTMLParseError, SourceLocation};
+
+// This test suite only tests the "shape" of the errors, aka that the variants of the errors returned are correct
+// It never tests the contents of the error messages, as those may change in the future. It does however test the error location
+
+#[test]
+fn mismatched_tags() {
+    fn ensure_mismatched_at(html: &str, at: usize, start_tag: &'static str, start_location: usize, end_tag: &'static str) {
+        let Err(err) = parse(html) else {
+            panic!("parse should fail");
+        };
+
+        match err.inner {
+            InnerHTMLParseError::MismatchedTags { start_tag: est, start_location: esl, end_tag: eend } => {
+                assert_eq!(est, start_tag);
+                assert_eq!(esl.0, start_location);
+                assert_eq!(eend, end_tag);
+            }
+            _ => { panic!("Expected parse to give MismatchedTags") }
+        }
+
+        assert_eq!(err.source_location, SourceLocation(at));
+    }
+
+    ensure_mismatched_at("<p></b>", 3, "p", 0, "b");
+    //                    0123456
+
+    ensure_mismatched_at("<span><p></p></div>", 13, "span", 0, "div");
+    //                    0123456789012345678
+
+    ensure_mismatched_at("<span><p></b></div>", 9, "p", 6, "b");
+    //                    0123456789012345678
+}
+
+#[test]
+fn unopened_tags() {
+    fn ensure_unopened_at(html: &str, at: usize, tag: &'static str) {
+        let Err(err) = parse(html) else {
+            panic!("parse should fail");
+        };
+
+        match err.inner {
+            InnerHTMLParseError::UnopenedTag { tag: etag } => {
+                assert_eq!(etag, tag);
+            }
+            _ => { panic!("Expected parse to give UnopenedTag") }
+        }
+
+        assert_eq!(err.source_location, SourceLocation(at));
+    }
+
+    ensure_unopened_at("</b>", 0, "b");
+    //                  0123
+
+    ensure_unopened_at("hi <span>hello</span></div>", 21, "div");
+    //                  012345678901234567890123456
+}
+
+#[test]
+fn unclosed_tags() {
+    fn ensure_unclosed_at(html: &str, at: usize, tag: &'static str) {
+        let Err(err) = parse(html) else {
+            panic!("parse should fail");
+        };
+
+        match err.inner {
+            InnerHTMLParseError::UnclosedTag { tag: etag } => {
+                assert_eq!(etag, tag);
+            }
+            _ => { panic!("Expected parse to give UnclosedTag") }
+        }
+
+        assert_eq!(err.source_location, SourceLocation(at));
+    }
+
+    ensure_unclosed_at("<b>", 0, "b");
+    //                  012
+
+    ensure_unclosed_at("<div><p>", 5, "p");
+    //                  01234567
+}
+
+#[test]
+fn invalid_tags() {
+    fn ensure_invalid_at(html: &str, at: usize, tag: &'static str) {
+        let Err(err) = parse(html) else {
+            panic!("parse should fail");
+        };
+
+        match err.inner {
+            InnerHTMLParseError::InvalidTag { tag: etag, .. } => {
+                assert_eq!(etag, tag);
+            }
+            _ => { panic!("Expected parse to give InvalidTag, gave {:?}", err) }
+        }
+
+        assert_eq!(err.source_location, SourceLocation(at));
+    }
+
+    // tag name cannot be all spaces
+    ensure_invalid_at("<   >", 0, "<   >");
+    ensure_invalid_at("<   />", 0, "<   />");
+    //                  01234
+
+    // no version in xml declaration
+    ensure_invalid_at("<?xml encoding=\"UTF-8\"?>", 0, "<?xml encoding=\"UTF-8\"?>");
+    //                  01234567
+
+    // no version in xml declaration
+    ensure_invalid_at("<?xml encoding=\"UTF-8\"?>", 0, "<?xml encoding=\"UTF-8\"?>");
+    //                  01234567
+}
+
+


### PR DESCRIPTION
This pull request does two things: introduce an error enum for possible failures during parsing, as well as track locations for all tokens to give information for errors. A few tests have been added to ensure the validity of the error tracking.

I made the decision to track locations as char indices rather than bytes in the source. This is mainly because this makes the tracking easier to write — we can simply call `.enumerate()` on the HTML in the `html_to_stack` function. I have tried to ensure that location gathering will never be O(n²), which could occur if you need to "count backwards" to see how long a thing you've kept in memory is in chars.